### PR TITLE
Added alternate attribute 'contains' check

### DIFF
--- a/UnitTests/AncestorTest.cs
+++ b/UnitTests/AncestorTest.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using NUnit.Framework;
 using XPathItUp;
 

--- a/UnitTests/DescendantTest.cs
+++ b/UnitTests/DescendantTest.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using NUnit.Framework;
 using XPathItUp;
 

--- a/UnitTests/ParentTest.cs
+++ b/UnitTests/ParentTest.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using NUnit.Framework;
 using XPathItUp;
 

--- a/UnitTests/PositionTest.cs
+++ b/UnitTests/PositionTest.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using NUnit.Framework;
 using XPathItUp;
 
@@ -111,13 +107,12 @@ namespace UnitTests
                     With.Child("select").With.Attribute("id").Containing("_myId").And.Position(1).ToXPathExpression();
 
             Assert.AreEqual("//td/span/following-sibling::td/div/div/div/select[contains(@id,'_myId') and position()=1]", xpath);
-
         }
 
         [Test]
         public void Will_Create_Xpath_Query_With_Attribute_And_Position_On_Child()
         {
-            string xpath = XPathFinder.Find.Tag("div").With.Child("span").With.Attribute("id","myId").And.Position(2).ToXPathExpression();
+            string xpath = XPathFinder.Find.Tag("div").With.Child("span").With.Attribute("id", "myId").And.Position(2).ToXPathExpression();
             Assert.AreEqual("//div/span[@id='myId' and position()=2]", xpath);
         }
 
@@ -134,9 +129,8 @@ namespace UnitTests
             string xpath = XPathFinder.Find.Tag("span").Containing("myText").And.Position(3).ToXPathExpression();
             Assert.AreEqual("//span[contains(.,'myText') and position()=3]", xpath);
 
-            xpath = XPathFinder.Find.Tag("span").Containing("myText").And.Attribute("class","test").And.Position(3).ToXPathExpression();
+            xpath = XPathFinder.Find.Tag("span").Containing("myText").And.Attribute("class", "test").And.Position(3).ToXPathExpression();
             Assert.AreEqual("//span[contains(.,'myText') and @class='test' and position()=3]", xpath);
         }
-
     }
 }

--- a/UnitTests/SiblingTest.cs
+++ b/UnitTests/SiblingTest.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using NUnit.Framework;
 using XPathItUp;
 

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -31,9 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.5.5.10112, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.2.1\lib\net40\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -42,9 +42,6 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="ThoughtWorks.Selenium.Core">
-      <HintPath>..\Lib\ThoughtWorks.Selenium.Core.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AncestorTest.cs" />
@@ -60,6 +57,9 @@
       <Project>{4C7A2325-337A-4527-A5A1-85533EDB4025}</Project>
       <Name>XPathFinder</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/UnitTests/XPathFinderTest.cs
+++ b/UnitTests/XPathFinderTest.cs
@@ -1,8 +1,4 @@
 using System;
-using System.Text;
-using System.Collections.Generic;
-using System.Linq;
-
 using XPathItUp;
 using NUnit.Framework;
 
@@ -11,7 +7,13 @@ namespace UnitTests
     [TestFixture]
     public class XPathFinderTest
     {
-        
+        [Test]
+        public void Will_Create_Xpath_Query_Where_Attribute_Includes_Entire_Value()
+        {
+            string xpath = XPathFinder.Find.Tag("div").With.Attribute("class").Including("entire-class-name").And.Child("p").With.Attribute("id", "p_id").ToXPathExpression();
+            Assert.AreEqual("//div[contains(concat(' ', normalize-space(@class), ' '), ' entire-class-name ')]/p[@id='p_id']", xpath);
+        }
+
         [Test]
         public void Will_Create_Xpath_Query_Where_Both_Parent_And_Child_Has_Exact_Attributes()
         {
@@ -32,7 +34,6 @@ namespace UnitTests
             string xpath = XPathFinder.Find.Tag("div").With.Attribute("id", "divId").And.Child("span").With.Attribute("id", "spanId").And.Attribute("class").Containing("my").ToXPathExpression();
             Assert.AreEqual("//div[@id='divId']/span[@id='spanId' and contains(@class,'my')]", xpath);
         }
-
 
         [Test]
         public void Will_Create_Xpath_Query_Where_Partial_Attribute_Is_Anded_With_Exact_Attribute()
@@ -553,18 +554,16 @@ namespace UnitTests
             Assert.AreEqual("//div[@class='someclass']", xpath);
         }
 
-        [ExpectedException(typeof(ArgumentNullException))]
         [Test]
         public void Find_Will_Throw_ArgumentNullException_If_Tag_Is_Null_Test()
         {
-            XPathFinder.Find.Tag(null);
+            Assert.Throws<ArgumentNullException>(()=>XPathFinder.Find.Tag(null));
         }
 
-        [ExpectedException(typeof(ArgumentNullException))]
         [Test]
         public void Find_Will_Throw_ArgumentNullException_If_Tag_Is_String_Empty_Test()
         {
-            XPathFinder.Find.Tag(string.Empty);
+            Assert.Throws<ArgumentNullException>(()=>XPathFinder.Find.Tag(string.Empty));
         }
     }
 }

--- a/UnitTests/packages.config
+++ b/UnitTests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.2.1" targetFramework="net40" />
+</packages>

--- a/XPathFinder/AttributeContainsElement.cs
+++ b/XPathFinder/AttributeContainsElement.cs
@@ -18,7 +18,7 @@ namespace XPathItUp
             this.ExpressionParts = expressionParts;
             this.attributeIndex = currentAttributeIndex;
             string attributeString = this.ExpressionParts[this.attributeIndex];
-            this.ExpressionParts[this.attributeIndex] = string.Format(attributeString, "contains(", "'" + value + "')");
+            this.ExpressionParts[this.attributeIndex] = string.Format(attributeString, "contains(", ",'" + value + "')");
         }
 
         public IAndElement And

--- a/XPathFinder/AttributeIncludesElement.cs
+++ b/XPathFinder/AttributeIncludesElement.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace XPathItUp
+{
+    internal class AttributeIncludesElement: Base, IAttributeContains
+    {
+        internal static IAttributeContains Create(List<string> expressionParts, string value, int currentAttributeIndex,bool appliesToParent)
+        {
+            return new AttributeIncludesElement(expressionParts, value, currentAttributeIndex, appliesToParent);
+        }
+
+        private AttributeIncludesElement(List<string> expressionParts, string value, int currentAttributeIndex, bool appliesToParent)
+        {
+            this.AppliesToParent = appliesToParent;
+            this.ExpressionParts = expressionParts;
+            this.attributeIndex = currentAttributeIndex;
+            string attributeString = this.ExpressionParts[this.attributeIndex];
+            this.ExpressionParts[this.attributeIndex] = string.Format(attributeString, "contains(concat(' ', normalize-space(", "), ' '), ' " + value + " ')");
+        }
+
+        public IAndElement And
+        {
+            get
+            {
+                return AndElement.Create(this.ExpressionParts, this.tagIndex, this.attributeIndex + 1,this.AppliesToParent);
+            }
+        }
+    }
+}

--- a/XPathFinder/ExtendedAttributeElement.cs
+++ b/XPathFinder/ExtendedAttributeElement.cs
@@ -17,11 +17,11 @@ namespace XPathItUp
 
             if (this.ExpressionParts[this.attributeIndex - 1] == " and ")
             {
-                this.ExpressionParts.Insert(this.attributeIndex,"{0}@" + name + ",{1}]");
+                this.ExpressionParts.Insert(this.attributeIndex,"{0}@" + name + "{1}]");
             }
             else
             {
-                this.ExpressionParts.Insert(this.attributeIndex,"[{0}@" + name + ",{1}]");
+                this.ExpressionParts.Insert(this.attributeIndex,"[{0}@" + name + "{1}]");
             }
 
         }
@@ -35,6 +35,10 @@ namespace XPathItUp
         {
             return AttributeContainsElement.Create(this.ExpressionParts, value,this.attributeIndex,this.AppliesToParent);
         }
-   
+
+        public IAttributeContains Including(string value)
+        {
+            return AttributeIncludesElement.Create(this.ExpressionParts, value,this.attributeIndex,this.AppliesToParent);
+        }
     }
 }

--- a/XPathFinder/IExtendedAttribute.cs
+++ b/XPathFinder/IExtendedAttribute.cs
@@ -9,5 +9,7 @@ namespace XPathItUp
     public interface IExtendedAttribute 
     {
         IAttributeContains Containing(string value);
+
+        IAttributeContains Including(string value);
     }
 }

--- a/XPathFinder/XPathFinder.csproj
+++ b/XPathFinder/XPathFinder.csproj
@@ -44,6 +44,7 @@
     <Compile Include="AndElement.cs" />
     <Compile Include="AttributeContainsElement.cs" />
     <Compile Include="AttributeElement.cs" />
+    <Compile Include="AttributeIncludesElement.cs" />
     <Compile Include="Base.cs" />
     <Compile Include="DescendantElement.cs" />
     <Compile Include="ExtendedAttributeElement.cs" />


### PR DESCRIPTION
Added a duplicate of the AttributeContainsElement class (named AttributeIncludesElement) that generates a stricter attribute search:

...Attribute("class").Including("entire-class-name") _results in_ //div[**contains(concat(' ', normalize-space(@class), ' '), ' entire-class-name ')**]

the standard contains(@class, 'foo') will match any class attributes containing foo anywhere in any of the class names, eg <div class="header-icon food-icon">. This alternate method pads the class attribute string with left and right spaces and adds spaces either side of the search term, so class="class-one food-icon" will only be found by a complete class name match, eg 'food-icon'

This could probably be implemented in a DRYer fashion but I need to get on with my work so this is just a suggestion really. Also I've only added one unit test as I've not had a proper look through everything yet.
